### PR TITLE
Support no_std targets using alloc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,11 @@ readme = "README.md"
 keywords = [ "ansi", "parsing", "terminal" ]
 edition = "2018"
 
+[features]
+default = ["std"]
+std = []
+alloc = []
+
 [dependencies]
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "cansi"
 description = "Catergorise ANSI - ANSI escape code parser and categoriser"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["kurt <kurtlawrence92@gmail.com>"]
 license = "MIT"
 homepage = "https://github.com/kurtlawrence/cansi"
 repository = "https://github.com/kurtlawrence/cansi"
 documentation = "https://docs.rs/cansi/"
 readme = "README.md"
-keywords = [ "ansi", "parsing", "terminal" ]
+keywords = [ "ansi", "parsing", "terminal", "no_std" ]
 edition = "2018"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ Look at progress and contribute on [github.](https://github.com/kurtlawrence/can
 
 `cansi` will parse text with ANSI escape sequences in it and return a deconstructed text with metadata around the colouring and styling. `cansi` is only concerned with `CSI` sequences, particuarly the `SGR` parameters. `cansi` will not construct escaped text, there are crates such as [`colored`](https://crates.io/crates/colored) that do a great job of colouring and styling text.
 
+## Targeting no_std
+This crate can use `alloc` in place of the standard library for no_std targets.
+The standard library is enabled by default, so disabling default features and enabling the
+`alloc` feature is required to use the crate this way.
+
+```toml
+[dependencies]
+cansi = { version = "2.1.0", default-features = false, features = ["alloc"] }
+```
+
 ## Example usage
 
 > This example was done using the `colored` crate to help with constructing the escaped text string. It will work with other tools that inject escape sequences into text strings (given they follow [ANSI specification](https://en.wikipedia.org/wiki/ANSI_escape_code)).

--- a/src/categorise.rs
+++ b/src/categorise.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+#[cfg(all(not(feature = "std"), feature = "alloc"))]
+use alloc::vec::Vec;
+
 const SEPARATOR: char = ';';
 
 /// Parses the text and returns each formatted slice in order.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,12 @@
 //!
 //! `cansi` will parse text with ANSI escape sequences in it and return a deconstructed text with metadata around the colouring and styling. `cansi` is only concerned with `CSI` sequences, particuarly the `SGR` parameters. `cansi` will not construct escaped text, there are crates such as [`colored`](https://crates.io/crates/colored) that do a great job of colouring and styling text.
 //!
+//! ## Targeting no_std
+//! This crate can use `alloc` in place of the standard library for no_std targets.
+//!
+//! The standard library is enabled by default as a cargo feature, so disabling default features and enabling the
+//! `alloc` feature is required to use the crate on embedded platforms.
+//!
 //! ## Example usage
 //!
 //! > This example was done using the `colored` crate to help with constructing the escaped text string. It will work with other tools that inject escape sequences into text strings (given they follow [ANSI specification](https://en.wikipedia.org/wiki/ANSI_escape_code)).
@@ -78,6 +84,8 @@
 //!   }
 //! );
 //! ```
+//!
+
 
 
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,17 @@
 //! );
 //! ```
 
+
+#![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs)]
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
+#[cfg(all(not(feature = "std"), feature = "alloc"))]
+use alloc::vec::Vec;
+#[cfg(all(not(feature = "std"), feature = "alloc"))]
+use alloc::string::String;
 
 mod categorise;
 mod parsing;

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -1,3 +1,6 @@
+#[cfg(all(not(feature = "std"), feature = "alloc"))]
+use alloc::vec::Vec;
+
 /// A match.
 pub struct Match<'t> {
     /// First byte index.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,9 @@
 use super::*;
 use colored::Colorize;
 
+#[cfg(all(not(feature = "std"), feature = "alloc"))]
+use alloc::vec::Vec;
+
 #[test]
 fn cover_other_parameters() {
     // colored doesn't always test all match arms, so i test here


### PR DESCRIPTION
Adds features that let you build and use this crate on no_std targets using `alloc`