### PR TITLE
Optional specifiers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cansi"
 description = "Catergorise ANSI - ANSI escape code parser and categoriser"
-version = "2.1.1"
+version = "2.2.0"
 authors = ["kurt <kurtlawrence92@gmail.com>"]
 license = "MIT"
 homepage = "https://github.com/kurtlawrence/cansi"
@@ -9,7 +9,7 @@ repository = "https://github.com/kurtlawrence/cansi"
 documentation = "https://docs.rs/cansi/"
 readme = "README.md"
 keywords = [ "ansi", "parsing", "terminal", "no_std" ]
-edition = "2018"
+edition = "2021"
 
 [features]
 default = ["std"]

--- a/src/categorise.rs
+++ b/src/categorise.rs
@@ -10,42 +10,13 @@ const SEPARATOR: char = ';';
 ///
 /// Each different text slice is returned in order such that the text without the escape characters can be reconstructed.
 /// There is a helper function (`construct_text_no_codes`) on `CategorisedSlices` for this.
+#[deprecated = "please use v3::categorise_text to move to API v3.0. \
+                this function will be removed with v3.0 of cansi"]
 pub fn categorise_text(text: &str) -> CategorisedSlices {
-    let matches = parse(text);
-
-    let mut sgr = SGR::default();
-
-    let mut lo = 0;
-
-    // will always less than or equal to matches + 1 in length, see tests
-    let mut slices: Vec<CategorisedSlice> = Vec::with_capacity(matches.len() + 1);
-
-    for m in matches {
-        // add in the text before CSI with the previous SGR format
-        if m.start != lo {
-            slices.push(CategorisedSlice::with_sgr(
-                sgr,
-                &text[lo..m.start],
-                lo,
-                m.start,
-            ));
-        }
-
-        sgr = handle_seq(&m);
-
-        lo = m.end;
-    }
-
-    if lo != text.len() {
-        slices.push(CategorisedSlice::with_sgr(
-            sgr,
-            &text[lo..text.len()],
-            lo,
-            text.len(),
-        ));
-    }
-
-    slices
+    categorise_text_v3(text)
+        .into_iter()
+        .map(Into::into)
+        .collect()
 }
 
 /// Parses the text and returns each formatted slice in order.

--- a/src/categorise.rs
+++ b/src/categorise.rs
@@ -69,9 +69,7 @@ pub fn categorise_text_v3(text: &str) -> v3::CategorisedSlices {
 fn handle_seq(m: &Match) -> SGR {
     // the slice we want to process is skipped of first two bytes (ESC[) and last byte (terminating byte)
     let slice = &m.text[2..(m.text.len() - 1)];
-    slice
-        .split(SEPARATOR)
-        .fold(SGR::default(), |x, s| adjust_sgr(x, s))
+    slice.split(SEPARATOR).fold(SGR::default(), adjust_sgr)
 }
 
 /// Apply the style seq to the SGR. Maps decimal numbers according to

--- a/src/categorise.rs
+++ b/src/categorise.rs
@@ -68,72 +68,67 @@ pub fn categorise_text_v3(text: &str) -> v3::CategorisedSlices {
 fn handle_seq(m: &Match) -> SGR {
     // the slice we want to process is skipped of first two bytes (ESC[) and last byte (terminating byte)
     let slice = &m.text[2..(m.text.len() - 1)];
-
-    let styles = slice.split(SEPARATOR);
-
-    let mut sgr = SGR::default();
-
-    for style in styles {
-        adjust_sgr(&mut sgr, style);
-    }
-
-    sgr
+    slice
+        .split(SEPARATOR)
+        .fold(SGR::default(), |x, s| adjust_sgr(x, s))
 }
 
 /// Apply the style seq to the SGR. Maps decimal numbers according to
 /// spec at https://en.wikipedia.org/wiki/ANSI_escape_code#Escape_sequences.
-fn adjust_sgr(sgr: &mut SGR, seq: &str) {
+fn adjust_sgr(mut sgr: SGR, seq: &str) -> SGR {
     match seq {
-        "0" => *sgr = SGR::default(),                  // 0
-        "1" => sgr.intensity = Intensity::Bold,        // 1
-        "2" => sgr.intensity = Intensity::Faint,       // 2
-        "3" => sgr.italic = true,                      // 3
-        "4" => sgr.underline = true,                   // 4
-        "5" => sgr.blink = true,                       // 5
-        "7" => sgr.reversed = true,                    // 7
-        "8" => sgr.hidden = true,                      // 8
-        "9" => sgr.strikethrough = true,               // 9
-        "22" => sgr.intensity = Intensity::Normal,     // 22
-        "23" => sgr.italic = false,                    // 23
-        "24" => sgr.underline = false,                 // 24
-        "25" => sgr.blink = false,                     // 25
-        "27" => sgr.reversed = false,                  // 27
-        "28" => sgr.hidden = false,                    // 28
-        "29" => sgr.strikethrough = false,             // 29
-        "30" => sgr.fg_colour = Color::Black,          // 30
-        "31" => sgr.fg_colour = Color::Red,            // 31
-        "32" => sgr.fg_colour = Color::Green,          // 32
-        "33" => sgr.fg_colour = Color::Yellow,         // 33
-        "34" => sgr.fg_colour = Color::Blue,           // 34
-        "35" => sgr.fg_colour = Color::Magenta,        // 35
-        "36" => sgr.fg_colour = Color::Cyan,           // 36
-        "37" => sgr.fg_colour = Color::White,          // 37
-        "40" => sgr.bg_colour = Color::Black,          // 40
-        "41" => sgr.bg_colour = Color::Red,            // 41
-        "42" => sgr.bg_colour = Color::Green,          // 42
-        "43" => sgr.bg_colour = Color::Yellow,         // 43
-        "44" => sgr.bg_colour = Color::Blue,           // 44
-        "45" => sgr.bg_colour = Color::Magenta,        // 45
-        "46" => sgr.bg_colour = Color::Cyan,           // 46
-        "47" => sgr.bg_colour = Color::White,          // 47
-        "90" => sgr.fg_colour = Color::BrightBlack,    // 90
-        "91" => sgr.fg_colour = Color::BrightRed,      // 91
-        "92" => sgr.fg_colour = Color::BrightGreen,    // 92
-        "93" => sgr.fg_colour = Color::BrightYellow,   // 93
-        "94" => sgr.fg_colour = Color::BrightBlue,     // 94
-        "95" => sgr.fg_colour = Color::BrightMagenta,  // 95
-        "96" => sgr.fg_colour = Color::BrightCyan,     // 96
-        "97" => sgr.fg_colour = Color::BrightWhite,    // 97
-        "100" => sgr.bg_colour = Color::BrightBlack,   // 100
-        "101" => sgr.bg_colour = Color::BrightRed,     // 101
-        "102" => sgr.bg_colour = Color::BrightGreen,   // 102
-        "103" => sgr.bg_colour = Color::BrightYellow,  // 103
-        "104" => sgr.bg_colour = Color::BrightBlue,    // 104
-        "105" => sgr.bg_colour = Color::BrightMagenta, // 105
-        "106" => sgr.bg_colour = Color::BrightCyan,    // 106
-        "107" => sgr.bg_colour = Color::BrightWhite,   // 107
+        "0" => return SGR::default(),                    // 0
+        "1" => sgr.intensity = Some(Intensity::Bold),    // 1
+        "2" => sgr.intensity = Some(Intensity::Faint),   // 2
+        "3" => sgr.italic = Some(true),                  // 3
+        "4" => sgr.underline = Some(true),               // 4
+        "5" => sgr.blink = Some(true),                   // 5
+        "7" => sgr.reversed = Some(true),                // 7
+        "8" => sgr.hidden = Some(true),                  // 8
+        "9" => sgr.strikethrough = Some(true),           // 9
+        "22" => sgr.intensity = Some(Intensity::Normal), // 22
+        "23" => sgr.italic = Some(false),                // 23
+        "24" => sgr.underline = Some(false),             // 24
+        "25" => sgr.blink = Some(false),                 // 25
+        "27" => sgr.reversed = Some(false),              // 27
+        "28" => sgr.hidden = Some(false),                // 28
+        "29" => sgr.strikethrough = Some(false),         // 29
+        "30" => sgr.fg = Some(Color::Black),             // 30
+        "31" => sgr.fg = Some(Color::Red),               // 31
+        "32" => sgr.fg = Some(Color::Green),             // 32
+        "33" => sgr.fg = Some(Color::Yellow),            // 33
+        "34" => sgr.fg = Some(Color::Blue),              // 34
+        "35" => sgr.fg = Some(Color::Magenta),           // 35
+        "36" => sgr.fg = Some(Color::Cyan),              // 36
+        "37" => sgr.fg = Some(Color::White),             // 37
+        "40" => sgr.bg = Some(Color::Black),             // 40
+        "41" => sgr.bg = Some(Color::Red),               // 41
+        "42" => sgr.bg = Some(Color::Green),             // 42
+        "43" => sgr.bg = Some(Color::Yellow),            // 43
+        "44" => sgr.bg = Some(Color::Blue),              // 44
+        "45" => sgr.bg = Some(Color::Magenta),           // 45
+        "46" => sgr.bg = Some(Color::Cyan),              // 46
+        "47" => sgr.bg = Some(Color::White),             // 47
+        "90" => sgr.fg = Some(Color::BrightBlack),       // 90
+        "91" => sgr.fg = Some(Color::BrightRed),         // 91
+        "92" => sgr.fg = Some(Color::BrightGreen),       // 92
+        "93" => sgr.fg = Some(Color::BrightYellow),      // 93
+        "94" => sgr.fg = Some(Color::BrightBlue),        // 94
+        "95" => sgr.fg = Some(Color::BrightMagenta),     // 95
+        "96" => sgr.fg = Some(Color::BrightCyan),        // 96
+        "97" => sgr.fg = Some(Color::BrightWhite),       // 97
+        "100" => sgr.bg = Some(Color::BrightBlack),      // 100
+        "101" => sgr.bg = Some(Color::BrightRed),        // 101
+        "102" => sgr.bg = Some(Color::BrightGreen),      // 102
+        "103" => sgr.bg = Some(Color::BrightYellow),     // 103
+        "104" => sgr.bg = Some(Color::BrightBlue),       // 104
+        "105" => sgr.bg = Some(Color::BrightMagenta),    // 105
+        "106" => sgr.bg = Some(Color::BrightCyan),       // 106
+        "107" => sgr.bg = Some(Color::BrightWhite),      // 107
         _ => (),
     }
+
+    sgr
 }
 
 #[cfg(test)]

--- a/src/categorise.rs
+++ b/src/categorise.rs
@@ -12,6 +12,7 @@ const SEPARATOR: char = ';';
 /// There is a helper function (`construct_text_no_codes`) on `CategorisedSlices` for this.
 #[deprecated = "please use v3::categorise_text to move to API v3.0. \
                 this function will be removed with v3.0 of cansi"]
+#[allow(deprecated)]
 pub fn categorise_text(text: &str) -> CategorisedSlices {
     categorise_text_v3(text)
         .into_iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,7 +249,7 @@ impl<'text, 'iter> Iterator for CategorisedLineIterator<'text, 'iter> {
             let (first, remainder) = split_on_new_line(slice.text);
 
             // push first slice on -- only if not empty
-            if first > 0 || v.len() == 0 {
+            if first > 0 || v.is_empty() {
                 v.push(slice.clone_style(&slice.text[..first], slice.start, slice.start + first));
             }
 
@@ -421,6 +421,7 @@ impl<'a> From<CategorisedSlice<'a>> for v3::CategorisedSlice<'a> {
 /// The formatting components `SGR (Select Graphic Rendition)`.
 /// [spec](https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters)
 #[derive(Clone, Copy, Default)]
+#[allow(clippy::upper_case_acronyms)]
 struct SGR {
     fg: Option<Color>,
     bg: Option<Color>,
@@ -472,7 +473,7 @@ pub enum Color {
 /// only require a change in import code.
 /// Note that version 3.0 will remove the deprecated version 2.0 items.
 pub mod v3 {
-    use super::{SGR, split_on_new_line};
+    use super::{split_on_new_line, SGR};
     pub use crate::{Color, Intensity};
 
     pub use super::categorise::categorise_text_v3 as categorise_text;
@@ -659,7 +660,7 @@ pub mod v3 {
                 let (first, remainder) = split_on_new_line(slice.text);
 
                 // push first slice on -- only if not empty
-                if first > 0 || v.len() == 0 {
+                if first > 0 || v.is_empty() {
                     v.push(slice.clone_style(
                         &slice.text[..first],
                         slice.start,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -472,8 +472,8 @@ pub enum Color {
 /// only require a change in import code.
 /// Note that version 3.0 will remove the deprecated version 2.0 items.
 pub mod v3 {
-    use super::split_on_new_line;
-    use crate::{Color, Intensity, SGR};
+    use super::{SGR, split_on_new_line};
+    pub use crate::{Color, Intensity};
 
     pub use super::categorise::categorise_text_v3 as categorise_text;
 
@@ -569,7 +569,7 @@ pub mod v3 {
     /// # Example
     /// ```rust
     /// # use colored::Colorize;
-    /// # use cansi::*;
+    /// # use cansi::v3::*;
     /// # colored::control::set_override(true);
     ///
     /// let s = format!("{}{}\nhow are you\r\ntoday", "hello, ".green(), "world".red());
@@ -578,10 +578,10 @@ pub mod v3 {
     ///
     /// let first = iter.next().unwrap();
     /// assert_eq!(first[0].text, "hello, ");
-    /// assert_eq!(first[0].fg_colour, Color::Green);
+    /// assert_eq!(first[0].fg, Some(Color::Green));
     ///
     /// assert_eq!(first[1].text, "world");
-    /// assert_eq!(first[1].fg_colour, Color::Red);
+    /// assert_eq!(first[1].fg, Some(Color::Red));
     ///
     /// assert_eq!(&construct_text_no_codes(&iter.next().unwrap()), "how are you");
     /// assert_eq!(&construct_text_no_codes(&iter.next().unwrap()), "today");
@@ -604,7 +604,7 @@ pub mod v3 {
     /// ```rust
     /// # use colored::Colorize;
     /// # colored::control::set_override(true);
-    /// # use cansi::*;
+    /// # use cansi::v3::*;
     ///
     /// let s = format!("{}{}\nhow are you\r\ntoday", "hello, ".green(), "world".red());
     /// let cat = categorise_text(&s);
@@ -612,10 +612,10 @@ pub mod v3 {
     ///
     /// let first = iter.next().unwrap();
     /// assert_eq!(first[0].text, "hello, ");
-    /// assert_eq!(first[0].fg_colour, Color::Green);
+    /// assert_eq!(first[0].fg, Some(Color::Green));
     ///
     /// assert_eq!(first[1].text, "world");
-    /// assert_eq!(first[1].fg_colour, Color::Red);
+    /// assert_eq!(first[1].fg, Some(Color::Red));
     ///
     /// assert_eq!(&construct_text_no_codes(&iter.next().unwrap()), "how are you");
     /// assert_eq!(&construct_text_no_codes(&iter.next().unwrap()), "today");
@@ -693,7 +693,7 @@ pub mod v3 {
     ///
     /// # Example
     /// ```rust
-    /// use cansi::*;
+    /// use cansi::v3::*;
     /// let categorised = categorise_text("\x1b[30mH\x1b[31me\x1b[32ml\x1b[33ml\x1b[34mo");
     /// assert_eq!("Hello", &construct_text_no_codes(&categorised));
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -323,35 +323,6 @@ pub struct CategorisedSlice<'text> {
 }
 
 impl<'text> CategorisedSlice<'text> {
-    const fn with_sgr(sgr: SGR, text: &'text str, start: usize, end: usize) -> Self {
-        let SGR {
-            fg_colour,
-            bg_colour,
-            intensity,
-            italic,
-            underline,
-            blink,
-            reversed,
-            hidden,
-            strikethrough,
-        } = sgr;
-
-        Self {
-            text,
-            start,
-            end,
-            fg_colour,
-            bg_colour,
-            intensity,
-            italic,
-            underline,
-            blink,
-            reversed,
-            hidden,
-            strikethrough,
-        }
-    }
-
     const fn clone_style(&self, text: &'text str, start: usize, end: usize) -> Self {
         let mut c = *self;
         c.text = text;
@@ -361,15 +332,28 @@ impl<'text> CategorisedSlice<'text> {
     }
 
     #[cfg(test)]
-    const fn default_style(text: &'text str, start: usize, end: usize) -> Self {
-        Self::with_sgr(SGR::default(), text, start, end)
+    fn default_style(text: &'text str, start: usize, end: usize) -> Self {
+        v3::CategorisedSlice::with_sgr(SGR::default(), text, start, end).into()
     }
 }
 
 /// Populates with defaults.
 impl<'a> From<v3::CategorisedSlice<'a>> for CategorisedSlice<'a> {
     fn from(x: v3::CategorisedSlice<'a>) -> Self {
-        let v3::CategorisedSlice { text, start, end, fg, bg, intensity, italic, underline, blink, reversed, hidden, strikethrough } = x;
+        let v3::CategorisedSlice {
+            text,
+            start,
+            end,
+            fg,
+            bg,
+            intensity,
+            italic,
+            underline,
+            blink,
+            reversed,
+            hidden,
+            strikethrough,
+        } = x;
 
         Self {
             text,
@@ -390,17 +374,17 @@ impl<'a> From<v3::CategorisedSlice<'a>> for CategorisedSlice<'a> {
 
 /// The formatting components `SGR (Select Graphic Rendition)`.
 /// [spec](https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters)
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Default)]
 struct SGR {
-    fg_colour: Color,
-    bg_colour: Color,
-    intensity: Intensity,
-    italic: bool,
-    underline: bool,
-    blink: bool,
-    reversed: bool,
-    hidden: bool,
-    strikethrough: bool,
+    fg: Option<Color>,
+    bg: Option<Color>,
+    intensity: Option<Intensity>,
+    italic: Option<bool>,
+    underline: Option<bool>,
+    blink: Option<bool>,
+    reversed: Option<bool>,
+    hidden: Option<bool>,
+    strikethrough: Option<bool>,
 }
 
 /// The emphasis (bold, faint) states.
@@ -434,22 +418,6 @@ pub enum Color {
     BrightMagenta,
     BrightCyan,
     BrightWhite,
-}
-
-impl SGR {
-    const fn default() -> Self {
-        SGR {
-            fg_colour: Color::White,
-            bg_colour: Color::Black,
-            intensity: Intensity::Normal,
-            italic: false,
-            underline: false,
-            blink: false,
-            reversed: false,
-            hidden: false,
-            strikethrough: false,
-        }
-    }
 }
 
 /// Update API for version 3.0 of the crate.
@@ -498,33 +466,32 @@ pub mod v3 {
 
     impl<'text> CategorisedSlice<'text> {
         pub(crate) const fn with_sgr(sgr: SGR, text: &'text str, start: usize, end: usize) -> Self {
-            todo!();
-            //         let SGR {
-            //             fg_colour,
-            //             bg_colour,
-            //             intensity,
-            //             italic,
-            //             underline,
-            //             blink,
-            //             reversed,
-            //             hidden,
-            //             strikethrough,
-            //         } = sgr;
-            //
-            //         Self {
-            //             text,
-            //             start,
-            //             end,
-            //             fg_colour,
-            //             bg_colour,
-            //             intensity,
-            //             italic,
-            //             underline,
-            //             blink,
-            //             reversed,
-            //             hidden,
-            //             strikethrough,
-            //         }
+            let SGR {
+                fg,
+                bg,
+                intensity,
+                italic,
+                underline,
+                blink,
+                reversed,
+                hidden,
+                strikethrough,
+            } = sgr;
+
+            Self {
+                text,
+                start,
+                end,
+                fg,
+                bg,
+                intensity,
+                italic,
+                underline,
+                blink,
+                reversed,
+                hidden,
+                strikethrough,
+            }
         }
 
         const fn clone_style(&self, text: &'text str, start: usize, end: usize) -> Self {
@@ -536,7 +503,7 @@ pub mod v3 {
         }
 
         #[cfg(test)]
-        const fn default_style(text: &'text str, start: usize, end: usize) -> Self {
+        fn default_style(text: &'text str, start: usize, end: usize) -> Self {
             Self::with_sgr(SGR::default(), text, start, end)
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,6 +203,7 @@ pub struct CategorisedLineIterator<'text, 'iter> {
     idx: usize,
     prev: Option<CategorisedSlice<'text>>,
 }
+
 /// The item type of `CategorisedLineIterator`.
 ///
 /// # Note
@@ -365,6 +366,28 @@ impl<'text> CategorisedSlice<'text> {
     }
 }
 
+/// Populates with defaults.
+impl<'a> From<v3::CategorisedSlice<'a>> for CategorisedSlice<'a> {
+    fn from(x: v3::CategorisedSlice<'a>) -> Self {
+        let v3::CategorisedSlice { text, start, end, fg, bg, intensity, italic, underline, blink, reversed, hidden, strikethrough } = x;
+
+        Self {
+            text,
+            start,
+            end,
+            fg_colour: fg.unwrap_or(Color::White),
+            bg_colour: bg.unwrap_or(Color::Black),
+            intensity: intensity.unwrap_or(Intensity::Normal),
+            italic: italic.unwrap_or_default(),
+            underline: underline.unwrap_or_default(),
+            blink: blink.unwrap_or_default(),
+            reversed: reversed.unwrap_or_default(),
+            hidden: hidden.unwrap_or_default(),
+            strikethrough: strikethrough.unwrap_or_default(),
+        }
+    }
+}
+
 /// The formatting components `SGR (Select Graphic Rendition)`.
 /// [spec](https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters)
 #[derive(Clone, Copy)]
@@ -426,5 +449,253 @@ impl SGR {
             hidden: false,
             strikethrough: false,
         }
+    }
+}
+
+/// Update API for version 3.0 of the crate.
+///
+/// To start using v3, import the items with `cansi::v3::*`. This way, moving to version 3.0 will
+/// only require a change in import code.
+/// Note that version 3.0 will remove the deprecated version 2.0 items.
+pub mod v3 {
+    use super::split_on_new_line;
+    use crate::{Color, Intensity, SGR};
+
+    pub use super::categorise::categorise_text_v3 as categorise_text;
+
+    /// Data structure that holds information about colouring and styling of a text slice.
+    #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+    pub struct CategorisedSlice<'text> {
+        /// The text slice.
+        pub text: &'text str,
+        /// _Inclusive_ starting byte position.
+        pub start: usize,
+        /// _Exclusive_ ending byte position.
+        pub end: usize,
+
+        /// The foreground (or text) colour.
+        pub fg: Option<Color>,
+        /// The background colour.
+        pub bg: Option<Color>,
+
+        /// The emphasis state (bold, faint, normal).
+        pub intensity: Option<Intensity>,
+
+        /// Italicised.
+        pub italic: Option<bool>,
+        /// Underlined.
+        pub underline: Option<bool>,
+
+        /// Slow blink text.
+        pub blink: Option<bool>,
+        /// Inverted colours. See [https://en.wikipedia.org/wiki/Reverse_video](https://en.wikipedia.org/wiki/Reverse_video).
+        pub reversed: Option<bool>,
+        /// Invisible text.
+        pub hidden: Option<bool>,
+        /// Struck-through.
+        pub strikethrough: Option<bool>,
+    }
+
+    impl<'text> CategorisedSlice<'text> {
+        pub(crate) const fn with_sgr(sgr: SGR, text: &'text str, start: usize, end: usize) -> Self {
+            todo!();
+            //         let SGR {
+            //             fg_colour,
+            //             bg_colour,
+            //             intensity,
+            //             italic,
+            //             underline,
+            //             blink,
+            //             reversed,
+            //             hidden,
+            //             strikethrough,
+            //         } = sgr;
+            //
+            //         Self {
+            //             text,
+            //             start,
+            //             end,
+            //             fg_colour,
+            //             bg_colour,
+            //             intensity,
+            //             italic,
+            //             underline,
+            //             blink,
+            //             reversed,
+            //             hidden,
+            //             strikethrough,
+            //         }
+        }
+
+        const fn clone_style(&self, text: &'text str, start: usize, end: usize) -> Self {
+            let mut c = *self;
+            c.text = text;
+            c.start = start;
+            c.end = end;
+            c
+        }
+
+        #[cfg(test)]
+        const fn default_style(text: &'text str, start: usize, end: usize) -> Self {
+            Self::with_sgr(SGR::default(), text, start, end)
+        }
+    }
+
+    /// Type definition of the collection of `CategorisedSlice`s.
+    pub type CategorisedSlices<'text> = Vec<CategorisedSlice<'text>>;
+
+    /// The item type of `CategorisedLineIterator`.
+    ///
+    /// # Note
+    /// > The type alias is the same as `CategorisedSlices`, so functions such as `construct_text_no_codes` will work.
+    pub type CategorisedLine<'text> = Vec<CategorisedSlice<'text>>;
+
+    /// Construct an iterator over each new line (`\n` or `\r\n`) and returns the categorised slices within those.
+    /// `CategorisedSlice`s that include a new line are split with the same style.
+    ///
+    /// # Example
+    /// ```rust
+    /// # use colored::Colorize;
+    /// # use cansi::*;
+    /// # colored::control::set_override(true);
+    ///
+    /// let s = format!("{}{}\nhow are you\r\ntoday", "hello, ".green(), "world".red());
+    /// let cat = categorise_text(&s);
+    /// let mut iter = line_iter(&cat);
+    ///
+    /// let first = iter.next().unwrap();
+    /// assert_eq!(first[0].text, "hello, ");
+    /// assert_eq!(first[0].fg_colour, Color::Green);
+    ///
+    /// assert_eq!(first[1].text, "world");
+    /// assert_eq!(first[1].fg_colour, Color::Red);
+    ///
+    /// assert_eq!(&construct_text_no_codes(&iter.next().unwrap()), "how are you");
+    /// assert_eq!(&construct_text_no_codes(&iter.next().unwrap()), "today");
+    /// assert_eq!(iter.next(), None);
+    /// ```
+    pub fn line_iter<'text, 'iter>(
+        categorised_slices: &'iter CategorisedSlices<'text>,
+    ) -> CategorisedLineIterator<'text, 'iter> {
+        CategorisedLineIterator {
+            slices: categorised_slices,
+            idx: 0,
+            prev: None,
+        }
+    }
+
+    /// An iterator structure for `CategorisedSlices`, iterating over each new line (`\n` or `\r\n`) and returns the categorised slices within those.
+    /// `CategorisedSlice`s that include a new line are split with the same style.
+    ///
+    /// # Example
+    /// ```rust
+    /// # use colored::Colorize;
+    /// # colored::control::set_override(true);
+    /// # use cansi::*;
+    ///
+    /// let s = format!("{}{}\nhow are you\r\ntoday", "hello, ".green(), "world".red());
+    /// let cat = categorise_text(&s);
+    /// let mut iter = line_iter(&cat);
+    ///
+    /// let first = iter.next().unwrap();
+    /// assert_eq!(first[0].text, "hello, ");
+    /// assert_eq!(first[0].fg_colour, Color::Green);
+    ///
+    /// assert_eq!(first[1].text, "world");
+    /// assert_eq!(first[1].fg_colour, Color::Red);
+    ///
+    /// assert_eq!(&construct_text_no_codes(&iter.next().unwrap()), "how are you");
+    /// assert_eq!(&construct_text_no_codes(&iter.next().unwrap()), "today");
+    /// assert_eq!(iter.next(), None);
+    /// ```
+    pub struct CategorisedLineIterator<'text, 'iter> {
+        slices: &'iter CategorisedSlices<'text>,
+        idx: usize,
+        prev: Option<CategorisedSlice<'text>>,
+    }
+
+    impl<'text, 'iter> Iterator for CategorisedLineIterator<'text, 'iter> {
+        type Item = CategorisedLine<'text>;
+        fn next(&mut self) -> Option<Self::Item> {
+            let mut v = Vec::new();
+
+            if let Some(prev) = &self.prev {
+                // need to test splitting this, might be more new lines in remainder
+                let (first, remainder) = split_on_new_line(prev.text);
+
+                // push first slice on -- only if not empty
+                // if first.len() == 0 it is because there is a sequence of new lines
+                v.push(prev.clone_style(&prev.text[..first], prev.start, prev.start + first));
+
+                if let Some(remainder) = remainder {
+                    // there is a remainder, which means that a new line was hit
+                    self.prev = Some(prev.clone_style(
+                        &prev.text[remainder..],
+                        prev.start + remainder,
+                        prev.end,
+                    ));
+                    return Some(v); // exit early
+                }
+
+                self.prev = None; // consumed prev
+            }
+
+            while let Some(slice) = self.slices.get(self.idx) {
+                self.idx += 1; // increment to next slice, always happens as well split this slice.
+
+                let (first, remainder) = split_on_new_line(slice.text);
+
+                // push first slice on -- only if not empty
+                if first > 0 || v.len() == 0 {
+                    v.push(slice.clone_style(
+                        &slice.text[..first],
+                        slice.start,
+                        slice.start + first,
+                    ));
+                }
+
+                if let Some(remainder) = remainder {
+                    // there is a remainder, which means that a new line was hit
+                    if !slice.text[remainder..].is_empty() {
+                        // not just a trailing new line.
+                        self.prev = Some(slice.clone_style(
+                            &slice.text[remainder..],
+                            slice.start + remainder,
+                            slice.end,
+                        ));
+                    }
+                    break; // exit looping
+                }
+            }
+
+            if v.is_empty() && self.idx >= self.slices.len() {
+                None // stop iterating if no slices were met and the index is above the slices len
+            } else {
+                Some(v)
+            }
+        }
+    }
+
+    /// Constructs a string of the categorised text without the ANSI escape characters.
+    ///
+    /// # Example
+    /// ```rust
+    /// use cansi::*;
+    /// let categorised = categorise_text("\x1b[30mH\x1b[31me\x1b[32ml\x1b[33ml\x1b[34mo");
+    /// assert_eq!("Hello", &construct_text_no_codes(&categorised));
+    /// ```
+    pub fn construct_text_no_codes(categorised_slices: &CategorisedSlices) -> String {
+        let slices = categorised_slices;
+        let mut s = String::with_capacity(
+            categorised_slices
+                .iter()
+                .map(|x| x.text.len())
+                .sum::<usize>(),
+        );
+        for sl in slices {
+            s.push_str(sl.text);
+        }
+
+        s
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,10 +111,14 @@ mod parsing;
 #[cfg(test)]
 mod tests;
 
+#[allow(deprecated)]
 pub use categorise::categorise_text;
 pub use parsing::{parse, Match};
 
 /// Type definition of the collection of `CategorisedSlice`s.
+#[deprecated = "please use v3::CategorisedSlices to move to API v3.0. \
+                this function will be removed with v3.0 of cansi"]
+#[allow(deprecated)]
 pub type CategorisedSlices<'text> = Vec<CategorisedSlice<'text>>;
 
 /// Constructs a string of the categorised text without the ANSI escape characters.
@@ -127,6 +131,7 @@ pub type CategorisedSlices<'text> = Vec<CategorisedSlice<'text>>;
 /// ```
 #[deprecated = "please use v3::construct_text_no_codes to move to API v3.0. \
                 this function will be removed with v3.0 of cansi"]
+#[allow(deprecated)]
 pub fn construct_text_no_codes(categorised_slices: &CategorisedSlices) -> String {
     let x = categorised_slices.iter().cloned().map(Into::into).collect();
     v3::construct_text_no_codes(&x)
@@ -156,6 +161,9 @@ pub fn construct_text_no_codes(categorised_slices: &CategorisedSlices) -> String
 /// assert_eq!(&construct_text_no_codes(&iter.next().unwrap()), "today");
 /// assert_eq!(iter.next(), None);
 /// ```
+#[deprecated = "please use v3::line_iter to move to API v3.0. \
+                this function will be removed with v3.0 of cansi"]
+#[allow(deprecated)]
 pub fn line_iter<'text, 'iter>(
     categorised_slices: &'iter CategorisedSlices<'text>,
 ) -> CategorisedLineIterator<'text, 'iter> {
@@ -190,6 +198,9 @@ pub fn line_iter<'text, 'iter>(
 /// assert_eq!(&construct_text_no_codes(&iter.next().unwrap()), "today");
 /// assert_eq!(iter.next(), None);
 /// ```
+#[deprecated = "please use v3::CategorisedLineIterator to move to API v3.0. \
+                this function will be removed with v3.0 of cansi"]
+#[allow(deprecated)]
 pub struct CategorisedLineIterator<'text, 'iter> {
     slices: &'iter CategorisedSlices<'text>,
     idx: usize,
@@ -200,8 +211,12 @@ pub struct CategorisedLineIterator<'text, 'iter> {
 ///
 /// # Note
 /// > The type alias is the same as `CategorisedSlices`, so functions such as `construct_text_no_codes` will work.
+#[deprecated = "please use v3::CategorisedLine to move to API v3.0. \
+                this function will be removed with v3.0 of cansi"]
+#[allow(deprecated)]
 pub type CategorisedLine<'text> = Vec<CategorisedSlice<'text>>;
 
+#[allow(deprecated)]
 impl<'text, 'iter> Iterator for CategorisedLineIterator<'text, 'iter> {
     type Item = CategorisedLine<'text>;
     fn next(&mut self) -> Option<Self::Item> {
@@ -283,6 +298,8 @@ fn split_on_new_line(txt: &str) -> (usize, Option<usize>) {
 
 /// Data structure that holds information about colouring and styling of a text slice.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[deprecated = "please use v3::CategorisedSlice to move to API v3.0. \
+                this function will be removed with v3.0 of cansi"]
 pub struct CategorisedSlice<'text> {
     /// The text slice.
     pub text: &'text str,
@@ -314,6 +331,7 @@ pub struct CategorisedSlice<'text> {
     pub strikethrough: bool,
 }
 
+#[allow(deprecated)]
 impl<'text> CategorisedSlice<'text> {
     const fn clone_style(&self, text: &'text str, start: usize, end: usize) -> Self {
         let mut c = *self;
@@ -330,6 +348,7 @@ impl<'text> CategorisedSlice<'text> {
 }
 
 /// Populates with defaults.
+#[allow(deprecated)]
 impl<'a> From<v3::CategorisedSlice<'a>> for CategorisedSlice<'a> {
     fn from(x: v3::CategorisedSlice<'a>) -> Self {
         let v3::CategorisedSlice {
@@ -364,6 +383,7 @@ impl<'a> From<v3::CategorisedSlice<'a>> for CategorisedSlice<'a> {
     }
 }
 
+#[allow(deprecated)]
 impl<'a> From<CategorisedSlice<'a>> for v3::CategorisedSlice<'a> {
     fn from(x: CategorisedSlice<'a>) -> Self {
         let CategorisedSlice {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,19 +125,11 @@ pub type CategorisedSlices<'text> = Vec<CategorisedSlice<'text>>;
 /// let categorised = categorise_text("\x1b[30mH\x1b[31me\x1b[32ml\x1b[33ml\x1b[34mo");
 /// assert_eq!("Hello", &construct_text_no_codes(&categorised));
 /// ```
+#[deprecated = "please use v3::construct_text_no_codes to move to API v3.0. \
+                this function will be removed with v3.0 of cansi"]
 pub fn construct_text_no_codes(categorised_slices: &CategorisedSlices) -> String {
-    let slices = categorised_slices;
-    let mut s = String::with_capacity(
-        categorised_slices
-            .iter()
-            .map(|x| x.text.len())
-            .sum::<usize>(),
-    );
-    for sl in slices {
-        s.push_str(sl.text);
-    }
-
-    s
+    let x = categorised_slices.iter().cloned().map(Into::into).collect();
+    v3::construct_text_no_codes(&x)
 }
 
 /// Construct an iterator over each new line (`\n` or `\r\n`) and returns the categorised slices within those.
@@ -368,6 +360,40 @@ impl<'a> From<v3::CategorisedSlice<'a>> for CategorisedSlice<'a> {
             reversed: reversed.unwrap_or_default(),
             hidden: hidden.unwrap_or_default(),
             strikethrough: strikethrough.unwrap_or_default(),
+        }
+    }
+}
+
+impl<'a> From<CategorisedSlice<'a>> for v3::CategorisedSlice<'a> {
+    fn from(x: CategorisedSlice<'a>) -> Self {
+        let CategorisedSlice {
+            text,
+            start,
+            end,
+            fg_colour,
+            bg_colour,
+            intensity,
+            italic,
+            underline,
+            blink,
+            reversed,
+            hidden,
+            strikethrough,
+        } = x;
+
+        Self {
+            text,
+            start,
+            end,
+            fg: Some(fg_colour),
+            bg: Some(bg_colour),
+            intensity: Some(intensity),
+            italic: Some(italic),
+            underline: Some(underline),
+            blink: Some(blink),
+            reversed: Some(reversed),
+            hidden: Some(hidden),
+            strikethrough: Some(strikethrough),
         }
     }
 }

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -18,7 +18,7 @@ const CSI: &str = "\x1b[";
 
 #[inline(always)]
 fn terminated_byte(byte: u8) -> bool {
-    byte >= 0x40 && byte <= 0x7e
+    (0x40..=0x7e).contains(&byte)
 }
 
 /// Parses ANSI escape codes from the given text, returning a vector of `Match`.
@@ -52,7 +52,7 @@ pub fn parse(text: &str) -> Vec<Match> {
             let end = end + 1;
 
             v.push(Match {
-                start: start,
+                start,
                 end,
                 text: &text[start..end],
             });


### PR DESCRIPTION
This alters the API to make `CategorisedSlices` have optional formatting applied.
This should fix downstream uses for transparency (https://github.com/kdr-aus/ogma/issues/150).

Since it is such a foundational API change, the _new_ API is housed in a `v3` module, with the intent to make `v3` replace everything when `cansi` moves to version 3.0.

For now, the current API is unchanged, with deprecation messages being used to move users to v3.